### PR TITLE
Update Flat Lit Toon Lite Transparent.shader

### DIFF
--- a/Assets/Cubed's Unity Shaders/Shaders/Flat Lit Toon Lite/Flat Lit Toon Lite Transparent.shader
+++ b/Assets/Cubed's Unity Shaders/Shaders/Flat Lit Toon Lite/Flat Lit Toon Lite Transparent.shader
@@ -88,7 +88,7 @@ Shader "CubedParadox/Flat Lit Toon Lite Transparent"
 			Name "FORWARD_DELTA"
 			Tags { "LightMode" = "ForwardAdd" }
 
-			Blend One One
+			Blend SrcAlpha One
             ZWrite Off
             Cull [_Cull]
 
@@ -124,7 +124,7 @@ Shader "CubedParadox/Flat Lit Toon Lite Transparent"
 				float lightContribution = dot(normalize(_WorldSpaceLightPos0.xyz - i.posWorld.xyz),normalDirection)*attenuation;
 				float3 directContribution = floor(saturate(lightContribution) * 2.0);
 				float3 finalColor = baseColor * lerp(0, _LightColor0.rgb, saturate(directContribution + ((1 - _Shadow) * attenuation)));
-				fixed4 finalRGBA = fixed4(finalColor,1) * i.col;
+				fixed4 finalRGBA = fixed4(finalColor, baseColor.a) * i.col;
 
 				UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
 				return finalRGBA;


### PR DESCRIPTION
Changed the ForwardAdd pass of Flat Lit Toon Lite Transparent to include influence from the texture/color mask's alpha value

Before:
![image](https://user-images.githubusercontent.com/42289116/44293089-1603c380-a257-11e8-975d-cdf2249d6e70.png)

After:
![image](https://user-images.githubusercontent.com/42289116/44293114-33389200-a257-11e8-9c2a-17af19ffd413.png)
