### PR TITLE
Created Flat Lit Toon Lite Fade and edited Lite Transparent to use premultiplied transparency

### DIFF
--- a/Assets/Cubed's Unity Shaders/Shaders/Flat Lit Toon Lite/Flat Lit Toon Lite Fade.shader
+++ b/Assets/Cubed's Unity Shaders/Shaders/Flat Lit Toon Lite/Flat Lit Toon Lite Fade.shader
@@ -1,0 +1,159 @@
+Shader "CubedParadox/Flat Lit Toon Lite Fade"
+{
+	Properties
+	{
+		_MainTex("MainTex", 2D) = "white" {}
+		_Color("Color", Color) = (1,1,1,1)
+		_ColorMask("ColorMask", 2D) = "black" {}
+		_Shadow("Shadow", Range(0, 1)) = 0.4
+		_EmissionMap("Emission Map", 2D) = "white" {}
+		[HDR]_EmissionColor("Emission Color", Color) = (0,0,0,1)
+		_BumpMap("BumpMap", 2D) = "bump" {}
+		_Cutoff("Alpha Cutoff", Range(0,1)) = 0.5
+        [HideInInspector] _Cull ("__cull", Float) = 2.0
+	}
+
+	SubShader
+	{
+		Tags { "Queue"="Transparent" "RenderType" = "Transparent" "IgnoreProjector"="True" }
+		Cull [_Cull]
+		Pass
+		{
+
+			Name "FORWARD"
+			Tags { "LightMode" = "ForwardBase" }
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite Off
+
+			CGPROGRAM
+            #define _ALPHABLEND_ON 1
+			#include "..\CGIncludes\FlatLitToonCoreLite.cginc"
+			#pragma vertex vert
+			#pragma fragment frag 
+
+			#pragma only_renderers d3d11 glcore gles
+			#pragma target 4.0
+
+			#pragma multi_compile_fwdbase
+			#pragma multi_compile_fog
+
+			float4 frag(VertexOutput i) : COLOR
+			{
+				float4 objPos = mul(unity_ObjectToWorld, float4(0,0,0,1));
+				i.normalDir = normalize(i.normalDir);
+				float3x3 tangentTransform = float3x3(i.tangentDir, i.bitangentDir, i.normalDir);
+				float3 _BumpMap_var = UnpackNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)));
+				float3 normalDirection = normalize(mul(_BumpMap_var.rgb, tangentTransform)); // Perturbed normals
+				float4 _MainTex_var = tex2D(_MainTex,TRANSFORM_TEX(i.uv0, _MainTex));
+				
+				float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz);
+				float3 lightColor = _LightColor0.rgb;
+				UNITY_LIGHT_ATTENUATION(attenuation, i, i.posWorld.xyz);
+
+				float4 _EmissionMap_var = tex2D(_EmissionMap,TRANSFORM_TEX(i.uv0, _EmissionMap));
+				float3 emissive = (_EmissionMap_var.rgb*_EmissionColor.rgb);
+				float4 _ColorMask_var = tex2D(_ColorMask,TRANSFORM_TEX(i.uv0, _ColorMask));
+				float4 baseColor = lerp((_MainTex_var.rgba*_Color.rgba),_MainTex_var.rgba,_ColorMask_var.r);
+				baseColor *= float4(i.col.rgb, 1);
+				
+				float3 lightmap = float4(1.0,1.0,1.0,1.0);
+				#ifdef LIGHTMAP_ON
+				lightmap = DecodeLightmap(UNITY_SAMPLE_TEX2D(unity_Lightmap, i.uv1 * unity_LightmapST.xy + unity_LightmapST.zw));
+				#endif
+
+				float3 reflectionMap = DecodeHDR(UNITY_SAMPLE_TEXCUBE_LOD(unity_SpecCube0, normalize((_WorldSpaceCameraPos - objPos.rgb)), 7), unity_SpecCube0_HDR)* 0.02;
+
+				float grayscalelightcolor = dot(_LightColor0.rgb, grayscale_vector);
+				float bottomIndirectLighting = grayscaleSH9(float3(0.0, -1.0, 0.0));
+				float topIndirectLighting = grayscaleSH9(float3(0.0, 1.0, 0.0));
+				float grayscaleDirectLighting = dot(lightDirection, normalDirection)*grayscalelightcolor*attenuation + grayscaleSH9(normalDirection);
+
+				float lightDifference = topIndirectLighting + grayscalelightcolor - bottomIndirectLighting;
+				float remappedLight = (grayscaleDirectLighting - bottomIndirectLighting) / lightDifference;
+
+				float3 indirectLighting = saturate((ShadeSH9(half4(0.0, -1.0, 0.0, 1.0)) + reflectionMap));
+				float3 directLighting = saturate((ShadeSH9(half4(0.0, 1.0, 0.0, 1.0)) + reflectionMap + _LightColor0.rgb));
+				float3 directContribution = saturate((1.0 - _Shadow) + floor(saturate(remappedLight) * 2.0));
+				float3 finalColor = emissive + (baseColor * lerp(indirectLighting, directLighting, directContribution));
+				fixed4 finalRGBA = fixed4(finalColor * lightmap, baseColor.a);
+
+				UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
+				return finalRGBA;
+			}
+			ENDCG
+		}
+
+		Pass
+		{
+			Name "FORWARD_DELTA"
+			Tags { "LightMode" = "ForwardAdd" }
+
+			Blend SrcAlpha One
+            ZWrite Off
+            Cull [_Cull]
+
+			CGPROGRAM
+            #define _ALPHABLEND_ON 1
+			#include "..\CGIncludes\FlatLitToonCoreLite.cginc"
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#pragma only_renderers d3d11 glcore gles
+			#pragma target 4.0
+
+			#pragma multi_compile_fwdadd_fullshadows
+			#pragma multi_compile_fog
+
+			float4 frag(VertexOutput i) : COLOR
+			{
+				float4 objPos = mul(unity_ObjectToWorld, float4(0,0,0,1));
+				i.normalDir = normalize(i.normalDir);
+				float3x3 tangentTransform = float3x3(i.tangentDir, i.bitangentDir, i.normalDir);
+				float3 _BumpMap_var = UnpackNormal(tex2D(_BumpMap,TRANSFORM_TEX(i.uv0, _BumpMap)));
+				float3 normalDirection = normalize(mul(_BumpMap_var.rgb, tangentTransform)); // Perturbed normals
+				float4 _MainTex_var = tex2D(_MainTex,TRANSFORM_TEX(i.uv0, _MainTex));
+
+				float3 lightDirection = normalize(_WorldSpaceLightPos0.xyz);
+				float3 lightColor = _LightColor0.rgb;
+				UNITY_LIGHT_ATTENUATION(attenuation, i, i.posWorld.xyz);
+	
+				float4 _ColorMask_var = tex2D(_ColorMask,TRANSFORM_TEX(i.uv0, _ColorMask));
+				float4 baseColor = lerp((_MainTex_var.rgba*_Color.rgba),_MainTex_var.rgba,_ColorMask_var.r);
+				baseColor *= float4(i.col.rgb, 1);
+
+				float lightContribution = dot(normalize(_WorldSpaceLightPos0.xyz - i.posWorld.xyz),normalDirection)*attenuation;
+				float3 directContribution = floor(saturate(lightContribution) * 2.0);
+				float3 finalColor = baseColor * lerp(0, _LightColor0.rgb, saturate(directContribution + ((1 - _Shadow) * attenuation)));
+				fixed4 finalRGBA = fixed4(finalColor,baseColor.a);
+
+				UNITY_APPLY_FOG(i.fogCoord, finalRGBA);
+				return finalRGBA;
+			}
+			ENDCG
+		}
+
+		Pass
+		{
+			Name "SHADOW_CASTER"
+			Tags{ "LightMode" = "ShadowCaster" }
+
+			ZWrite On ZTest LEqual
+            Cull [_Cull]
+
+			CGPROGRAM
+            #define _ALPHABLEND_ON 1
+			#include "..\CGIncludes\FlatLitToonShadows.cginc"
+			#pragma multi_compile_shadowcaster
+			#pragma fragmentoption ARB_precision_hint_fastest
+
+			#pragma only_renderers d3d11 glcore gles
+			#pragma target 4.0
+
+			#pragma vertex vertShadowCaster
+			#pragma fragment fragShadowCaster
+			ENDCG
+		}
+	}
+	FallBack "Diffuse"
+    CustomEditor "CubedsUnityShaders.FlatLitToonLiteCutoutInspector"
+}

--- a/Assets/Cubed's Unity Shaders/Shaders/Flat Lit Toon Lite/Flat Lit Toon Lite Transparent.shader
+++ b/Assets/Cubed's Unity Shaders/Shaders/Flat Lit Toon Lite/Flat Lit Toon Lite Transparent.shader
@@ -22,11 +22,11 @@ Shader "CubedParadox/Flat Lit Toon Lite Transparent"
 
 			Name "FORWARD"
 			Tags { "LightMode" = "ForwardBase" }
-            Blend SrcAlpha OneMinusSrcAlpha
+            Blend One OneMinusSrcAlpha
             ZWrite Off
 
 			CGPROGRAM
-            #define _ALPHABLEND_ON 1
+            #define _ALPHAPREMULTIPLY_ON 1
 			#include "..\CGIncludes\FlatLitToonCoreLite.cginc"
 			#pragma vertex vert
 			#pragma fragment frag 
@@ -93,7 +93,7 @@ Shader "CubedParadox/Flat Lit Toon Lite Transparent"
             Cull [_Cull]
 
 			CGPROGRAM
-            #define _ALPHABLEND_ON 1
+            #define _ALPHAPREMULTIPLY_ON 1
 			#include "..\CGIncludes\FlatLitToonCoreLite.cginc"
 			#pragma vertex vert
 			#pragma fragment frag
@@ -141,7 +141,7 @@ Shader "CubedParadox/Flat Lit Toon Lite Transparent"
             Cull [_Cull]
 
 			CGPROGRAM
-            #define _ALPHABLEND_ON 1
+            #define _ALPHAPREMULTIPLY_ON 1
 			#include "..\CGIncludes\FlatLitToonShadows.cginc"
 			#pragma multi_compile_shadowcaster
 			#pragma fragmentoption ARB_precision_hint_fastest


### PR DESCRIPTION
The existing Lite Transparent shader's ForwardBase pass has the blend state and shader flags that Fade should have, though its ForwardAdd pass is premultiplied. The Transparent Lite shader variant has be edited to use premultiplied transparency Base and Add passes, and a Fade shader variant has been added for traditional transaprency.